### PR TITLE
Update pandoc-latex-environement commit dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-frontmatter==0.5.0
--e git+https://github.com/chdemko/pandoc-latex-environment.git@189abc88118e99d71594d771f3c2a29f7ea635bf#egg=pandoc-latex-environment
+-e git+https://github.com/chdemko/pandoc-latex-environment.git@89c86963aaa823e606d44bcdcf5340cf03350eac#egg=pandoc-latex-environment
 click==7.1.2
 emoji


### PR DESCRIPTION
Fix pypandoc deps issue. Replaces https://github.com/etalab/guides.etalab.gouv.fr/pull/169.

Latest pandoc-latex-environment don't require pypandoc since https://github.com/chdemko/pandoc-latex-environment/commit/aafec7bb2fd1569e97568129c0726a832ca4387b.

Tested a pdf generation locally :)