### PR TITLE
Use babel, not polyglossia, with xelatex

### DIFF
--- a/eisvogel.latex
+++ b/eisvogel.latex
@@ -424,27 +424,10 @@ $for(header-includes)$
 $header-includes$
 $endfor$
 $if(lang)$
-\ifxetex
-  $if(mainfont)$
-  $else$
-  % See issue https://github.com/reutenauer/polyglossia/issues/127
-  \renewcommand*\familydefault{\sfdefault}
-  $endif$
-  % Load polyglossia as late as possible: uses bidi with RTL langages (e.g. Hebrew, Arabic)
-  \usepackage{polyglossia}
-  \setmainlanguage[$for(polyglossia-lang.options)$$polyglossia-lang.options$$sep$,$endfor$]{$polyglossia-lang.name$}
-$for(polyglossia-otherlangs)$
-  \setotherlanguage[$for(polyglossia-otherlangs.options)$$polyglossia-otherlangs.options$$sep$,$endfor$]{$polyglossia-otherlangs.name$}
-$endfor$
-\else
-  \usepackage[$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
+\usepackage[$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
 % get rid of language-specific shorthands (see #6817):
 \let\LanguageShortHands\languageshorthands
 \def\languageshorthands#1{}
-$if(babel-newcommands)$
-  $babel-newcommands$
-$endif$
-\fi
 $endif$
 \ifluatex
   \usepackage{selnolig}  % disable illegal ligatures


### PR DESCRIPTION
We're encountering a bug when generating templates in guides.etalab.gouv.fr : https://github.com/etalab/guides.etalab.gouv.fr/actions/runs/5458345735/jobs/9940315010.
```
! Argument of \str_uppercase:n has an extra }.
<inserted text>
                \par
l.136   \setmainlanguage[]{}
```

This PRs propose a fix following default template update in https://github.com/jgm/pandoc/pull/7562.

See also https://github.com/Wandmalfarbe/pandoc-latex-template/issues/278.